### PR TITLE
Add missing boost includes and fix ambiguous function call

### DIFF
--- a/src/molecule/shell_base.cc
+++ b/src/molecule/shell_base.cc
@@ -23,6 +23,7 @@
 //
 
 
+#include <boost/archive/basic_archive.hpp>
 #include <sstream>
 #include <src/molecule/shell_base.h>
 

--- a/src/molecule/shellecp.cc
+++ b/src/molecule/shellecp.cc
@@ -22,7 +22,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-
+#include <boost/archive/basic_archive.hpp>
 #include <sstream>
 #include <src/molecule/shellecp.h>
 

--- a/src/util/input/input.cc
+++ b/src/util/input/input.cc
@@ -24,6 +24,7 @@
 
 #include <fstream>
 #include <string>
+#include <boost/archive/basic_archive.hpp>
 #include <src/util/input/input.h>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/xml_parser.hpp>

--- a/src/util/math/btas_interface.cc
+++ b/src/util/math/btas_interface.cc
@@ -22,6 +22,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <boost/archive/basic_archive.hpp>
 #include <src/util/serialization.h>
 #include <src/util/math/btas_interface.h>
 

--- a/src/util/math/sphharmonics.cc
+++ b/src/util/math/sphharmonics.cc
@@ -82,7 +82,7 @@ complex<double> SphHarmonics::ylm() const {
   if (am > l)
     throw runtime_error ("SphHarmonics.ylm: |m| > l");
 
-  const double plm = legendre.compute(l, am, cth);
+  const double plm = ::legendre.compute(l, am, cth);
   double fact = 1.0;
   for (int i = 1; i <= 2*am; ++i)
     fact *= l - am + i;
@@ -109,7 +109,7 @@ double SphHarmonics::zlm() const {
   const double cth = cos(theta_);
   const int am = abs(m);
 
-  const double plm = legendre.compute(l, am, cth);
+  const double plm = ::legendre.compute(l, am, cth);
 
   double coef0 = 1.0;
   for (unsigned int i = l + am; i > (l - am); i--) coef0 *= i;
@@ -133,7 +133,7 @@ double SphHarmonics::zlm(const int l, const int m) const {
     throw runtime_error ("SphHarmonics.zlm: |m| > l");
   const double cth = cos(theta_);
 
-  const double plm = legendre.compute(l, am, cth);
+  const double plm = ::legendre.compute(l, am, cth);
 
   double coef0 = 1.0;
   for (unsigned int i = l + am; i > (l - am); i--) coef0 *= i;


### PR DESCRIPTION
Fixes boost error
```
/usr/include/boost/property_tree/ptree_serialization.hpp:69:47: error: ‘library_version’ was not declared in this scope
```